### PR TITLE
9/fix implementar teste de retorno do progresso do exercício

### DIFF
--- a/src/controllers/ExerciseController.test.ts
+++ b/src/controllers/ExerciseController.test.ts
@@ -27,14 +27,14 @@ describe('ExerciseController - updateExerciseStatus', () => {
         controller = new ExerciseController()
         controller['exerciseService'] = mockExerciseService
 
-        req = { params: { topicId: "1", itemId: "1" }, body: { ItemStatus: "NotStarted" }, user: { email: "test@gmail.com" } }
+        req = { params: { topicId: "1", itemId: "1" }, body: { itemStatus: "NotStarted" }, user: { email: "test@gmail.com" } }
         res = {
             status: jest.fn().mockReturnThis(),
             json: jest.fn()
         }
     })
 
-    it('Usuário não autenticado', async () => {
+    it('deve retornar "User not authenticated" se o usuário não estiver autenticado', async () => {
         req.user = undefined
 
         await controller.updateExerciseStatus(req as Request, res as Response)
@@ -43,13 +43,78 @@ describe('ExerciseController - updateExerciseStatus', () => {
         expect(res.json).toHaveBeenCalledWith({ message: "User not authenticated." })
     })
 
-    it('Usuário não encontrado', async () => {
+    it('deve retornar "User not found" se o usuário não for encontrado', async () => {
+        mockExerciseService.findUserByEmail.mockResolvedValue(null)
         
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.json).toHaveBeenCalledWith({ message: "User not found." })
+    })
+
+    it('deve retornar "Invalid or missing status value" se o status for inválido', async () => {
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+
+        mockExerciseService.validateStatus.mockResolvedValue(false)
         
+        await controller.updateExerciseStatus(req as Request, res as Response)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ message: "Invalid or missing status value." })
+    })
+
+    it('deve retornar "Progress record not found for user 1 and item 1, 1" se o progresso não for encontrado', async () => {
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+
+        mockExerciseService.validateStatus.mockResolvedValue(true)
+
+        mockExerciseService.findProgress.mockRejectedValue(new Error("Progress record not found for user 1 and item 1, 1."));
+        
+        await controller.updateExerciseStatus(req as Request, res as Response)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ message: "Progress record not found for user 1 and item 1, 1." })
+    })
+
+    it('deve retornar "The status is already up to date" se o status já estiver atualizado', async () => {
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+
+        mockExerciseService.validateStatus.mockResolvedValue(true)
+
+        mockExerciseService.findProgress.mockResolvedValue({ id: 1, itemId: "rw12346789", itemStatus: "NotStarted", elementType: "Exercise", topicId: "rw987654321", userId: 1 });
+
+        await controller.updateExerciseStatus(req as Request, res as Response)
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({ message: "The status is already up to date." })
+    })
+
+    it('deve retornar o progresso atualizado ao mudar o status', async () => {
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+
+        mockExerciseService.validateStatus.mockResolvedValue(true);
+
+        mockExerciseService.findProgress.mockResolvedValue({ id: 1, itemId: "rw12346789", itemStatus: "InProgress", elementType: "Exercise", topicId: "rw987654321", userId: 1 });
+
+        mockExerciseService.updatedProgress.mockResolvedValue([{ id: 1, itemId: "rw12346789", itemStatus: "NotStarted", elementType: "Exercise", userId: 1 }]);
+
+        await controller.updateExerciseStatus(req as Request, res as Response);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith([{ id: 1, itemId: "rw12346789", itemStatus: "NotStarted", elementType: "Exercise", userId: 1 }]);
+    });
+
+    it('deve retornar "Internal server error while processing the request" em caso de erro no servidor', async () => {
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        mockExerciseService.validateStatus.mockResolvedValue(true)
+        
+        mockExerciseService.findProgress.mockRejectedValue(new Error("Internal server error"));
+    
+        await controller.updateExerciseStatus(req as Request, res as Response)
+    
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(res.json).toHaveBeenCalledWith({ message: "Internal server error while processing the request." })
     })
 
 })

--- a/src/controllers/ExerciseController.test.ts
+++ b/src/controllers/ExerciseController.test.ts
@@ -40,7 +40,7 @@ describe('ExerciseController - updateExerciseStatus', () => {
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(401)
-        expect(res.json).toHaveBeenCalledWith({ message: "User not authenticated." })
+        expect(res.json).toHaveBeenCalledWith({ message: "User not authenticated" })
     })
 
     it('deve retornar "User not found" se o usuário não for encontrado', async () => {
@@ -49,7 +49,7 @@ describe('ExerciseController - updateExerciseStatus', () => {
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(404)
-        expect(res.json).toHaveBeenCalledWith({ message: "User not found." })
+        expect(res.json).toHaveBeenCalledWith({ message: "User not found" })
     })
 
     it('deve retornar "Invalid or missing status value" se o status for inválido', async () => {
@@ -87,7 +87,7 @@ describe('ExerciseController - updateExerciseStatus', () => {
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(200)
-        expect(res.json).toHaveBeenCalledWith({ message: "The status is already up to date." })
+        expect(res.json).toHaveBeenCalledWith({ message: "Status value is already being used" })
     })
 
     it('deve retornar o progresso atualizado ao mudar o status', async () => {
@@ -116,7 +116,7 @@ describe('ExerciseController - updateExerciseStatus', () => {
         await controller.updateExerciseStatus(req as Request, res as Response)
     
         expect(res.status).toHaveBeenCalledWith(500)
-        expect(res.json).toHaveBeenCalledWith({ message: "Internal server error while processing the request." })
+        expect(res.json).toHaveBeenCalledWith({ message: "Internal server error while processing the request" })
     })
 
 })

--- a/src/controllers/ExerciseController.test.ts
+++ b/src/controllers/ExerciseController.test.ts
@@ -14,12 +14,12 @@ enum ElementType {
 }
 
 jest.mock("../services/ExerciseService")
-
-describe('ExerciseController - updateExerciseStatus', () => {
     let controller: ExerciseController
     let req: Partial<Request>
     let res: Partial<Response>
     let mockExerciseService: jest.Mocked<ExerciseService>
+
+describe('ExerciseController - updateExerciseStatus', () => {
 
     beforeEach(() => {
         mockExerciseService = new ExerciseService() as jest.Mocked<ExerciseService>
@@ -97,12 +97,14 @@ describe('ExerciseController - updateExerciseStatus', () => {
 
         mockExerciseService.findProgress.mockResolvedValue({ id: 1, itemId: "rw12346789", itemStatus: "InProgress", elementType: "Exercise", topicId: "rw987654321", userId: 1 });
 
-        mockExerciseService.updatedProgress.mockResolvedValue([{ id: 1, itemId: "rw12346789", itemStatus: "NotStarted", elementType: "Exercise", userId: 1 }]);
+        const progress = [{ id: 1, itemId: "rw12346789", itemStatus: ItemStatus.NotStarted, elementType: ElementType.Exercise, userId: 1 }]
+        
+        mockExerciseService.updatedProgress.mockResolvedValue(progress);
 
         await controller.updateExerciseStatus(req as Request, res as Response);
 
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith([{ id: 1, itemId: "rw12346789", itemStatus: "NotStarted", elementType: "Exercise", userId: 1 }]);
+        expect(res.json).toHaveBeenCalledWith(progress);
     });
 
     it('deve retornar "Internal server error while processing the request" em caso de erro no servidor', async () => {
@@ -120,10 +122,6 @@ describe('ExerciseController - updateExerciseStatus', () => {
 })
 
 describe('ExerciseController - getTopicExercisesStatus', () => {
-    let controller: ExerciseController
-    let req: Partial<Request>
-    let res: Partial<Response>
-    let mockExerciseService: jest.Mocked<ExerciseService>
 
     beforeEach(() => {
         mockExerciseService = new ExerciseService() as jest.Mocked<ExerciseService>

--- a/src/controllers/ExerciseController.test.ts
+++ b/src/controllers/ExerciseController.test.ts
@@ -15,6 +15,45 @@ enum ElementType {
 
 jest.mock("../services/ExerciseService")
 
+describe('ExerciseController - updateExerciseStatus', () => {
+    let controller: ExerciseController
+    let req: Partial<Request>
+    let res: Partial<Response>
+    let mockExerciseService: jest.Mocked<ExerciseService>
+
+    beforeEach(() => {
+        mockExerciseService = new ExerciseService() as jest.Mocked<ExerciseService>
+
+        controller = new ExerciseController()
+        controller['exerciseService'] = mockExerciseService
+
+        req = { params: { topicId: "1", itemId: "1" }, body: { ItemStatus: "NotStarted" }, user: { email: "test@gmail.com" } }
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        }
+    })
+
+    it('Usuário não autenticado', async () => {
+        req.user = undefined
+
+        await controller.updateExerciseStatus(req as Request, res as Response)
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ message: "User not authenticated." })
+    })
+
+    it('Usuário não encontrado', async () => {
+        
+        await controller.updateExerciseStatus(req as Request, res as Response)
+
+        expect(res.status).toHaveBeenCalledWith(404)
+        expect(res.json).toHaveBeenCalledWith({ message: "User not found." })
+        
+    })
+
+})
+
 describe('ExerciseController - getTopicExercisesStatus', () => {
     let controller: ExerciseController
     let req: Partial<Request>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,10 +7,9 @@ const router = express.Router()
 router.get('/', (req, res) => {
     res.send('Welcome to the homepage');
 });
-//Rota antiga para teste//
-router.put('/exercise/:itemId/status', new ExerciseController().updateExerciseStatus);
-//Rota Nova para salvar progresso//
+
 router.put('/topic/:topicId/item/:itemId/status', validateTokenMiddleware, (req, res) => new ExerciseController().updateExerciseStatus(req, res));
+
 router.get('/topic/:topicId/item', validateTokenMiddleware, (req, res) => new ExerciseController().getTopicExercisesStatus(req, res))
 export default router;
 


### PR DESCRIPTION
#9 - fix implementar teste de retorno do progresso do exercício
====
  
### 🆙 CHANGELOG

- Testes para cada caso de uso da controller: ExerciseController - updateExerciseStatus

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Garantir que a main está atualizada com git pull
- [x] Ir para branch 9/fix implementar teste de retorno do progresso do exercício
- [x] Rodar comando git pull
- [x] Verificar código do arquivo src/controllers/ExerciseController.test.ts
- [x] Rodar comando npm test, para verificar o resultado dos testes
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada

