### PR TITLE
13/ Feat Endpoint para salvar usuário

### DIFF
--- a/prisma/migrations/20250218183742_criando_coluna_de_provider_para_modelo_user/migration.sql
+++ b/prisma/migrations/20250218183742_criando_coluna_de_provider_para_modelo_user/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email,provider]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `provider` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "User_email_key";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "provider" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_provider_key" ON "User"("email", "provider");

--- a/prisma/migrations/20250218184827_criando_enum_para_coluna_provider/migration.sql
+++ b/prisma/migrations/20250218184827_criando_enum_para_coluna_provider/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - Changed the type of `provider` on the `User` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- CreateEnum
+CREATE TYPE "Provider" AS ENUM ('Google', 'Github', 'Linkedin', 'Facebook');
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "provider",
+ADD COLUMN     "provider" "Provider" NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_provider_key" ON "User"("email", "provider");

--- a/prisma/migrations/20250221180946_removendo_chave_composta_para_email_e_provider/migration.sql
+++ b/prisma/migrations/20250221180946_removendo_chave_composta_para_email_e_provider/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `loginDate` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Changed the type of `provider` on the `User` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropIndex
+DROP INDEX "User_email_provider_key";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "loginDate" TIMESTAMP(3) NOT NULL,
+DROP COLUMN "provider",
+ADD COLUMN     "provider" TEXT NOT NULL;
+
+-- DropEnum
+DROP TYPE "Provider";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,8 @@ datasource db {
 model User {
   id       Int        @id @default(autoincrement())
   email    String     @unique
+  provider String     
+  loginDate DateTime
   Progress Progress[]
 }
 

--- a/src/controllers/ExerciseController.ts
+++ b/src/controllers/ExerciseController.ts
@@ -37,7 +37,7 @@ export class ExerciseController {
             }
     
             if (currentProgress.itemStatus === itemStatus) {
-                return res.status(200).json({ message: "Status value is already being used" })
+                return res.status(200).json({ message: "Status value is already being used" });
             }
 
             const updatedProgress = await this.exerciseService.updatedProgress(user.id, itemId, itemStatus, topicId)

--- a/src/controllers/exercise/ExerciseController.test.ts
+++ b/src/controllers/exercise/ExerciseController.test.ts
@@ -1,6 +1,6 @@
 import { ExerciseController } from "./ExerciseController"
 import { Request, Response } from "express"
-import { ExerciseService } from "../services/ExerciseService"
+import { ExerciseService } from "../../services/ExerciseService"
 
 enum ItemStatus {
     Completed = "Completed",
@@ -13,11 +13,11 @@ enum ElementType {
     Video = "Video",
 }
 
-jest.mock("../services/ExerciseService")
-    let controller: ExerciseController
-    let req: Partial<Request>
-    let res: Partial<Response>
-    let mockExerciseService: jest.Mocked<ExerciseService>
+jest.mock("../../services/ExerciseService")
+let controller: ExerciseController
+let req: Partial<Request>
+let res: Partial<Response>
+let mockExerciseService: jest.Mocked<ExerciseService>
 
 describe('ExerciseController - updateExerciseStatus', () => {
 
@@ -45,7 +45,7 @@ describe('ExerciseController - updateExerciseStatus', () => {
 
     it('deve retornar "User not found" se o usuário não for encontrado', async () => {
         mockExerciseService.findUserByEmail.mockResolvedValue(null)
-        
+
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(404)
@@ -53,10 +53,12 @@ describe('ExerciseController - updateExerciseStatus', () => {
     })
 
     it('deve retornar "Invalid or missing status value" se o status for inválido', async () => {
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date });
 
         mockExerciseService.validateStatus.mockResolvedValue(false)
-        
+
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(400)
@@ -64,12 +66,14 @@ describe('ExerciseController - updateExerciseStatus', () => {
     })
 
     it('deve retornar "Progress record not found for user 1 and item 1, 1" se o progresso não for encontrado', async () => {
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date });
 
         mockExerciseService.validateStatus.mockResolvedValue(true)
 
         mockExerciseService.findProgress.mockRejectedValue(new Error("Progress record not found for user 1 and item 1, 1."));
-        
+
         await controller.updateExerciseStatus(req as Request, res as Response)
 
         expect(res.status).toHaveBeenCalledWith(400)
@@ -78,7 +82,9 @@ describe('ExerciseController - updateExerciseStatus', () => {
 
     it('deve retornar "The status is already up to date" se o status já estiver atualizado', async () => {
 
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date });
 
         mockExerciseService.validateStatus.mockResolvedValue(true)
 
@@ -91,14 +97,16 @@ describe('ExerciseController - updateExerciseStatus', () => {
     })
 
     it('deve retornar o progresso atualizado ao mudar o status', async () => {
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date });
 
         mockExerciseService.validateStatus.mockResolvedValue(true);
 
         mockExerciseService.findProgress.mockResolvedValue({ id: 1, itemId: "rw12346789", itemStatus: "InProgress", elementType: "Exercise", topicId: "rw987654321", userId: 1 });
 
         const progress = [{ id: 1, itemId: "rw12346789", itemStatus: ItemStatus.NotStarted, elementType: ElementType.Exercise, userId: 1 }]
-        
+
         mockExerciseService.updatedProgress.mockResolvedValue(progress);
 
         await controller.updateExerciseStatus(req as Request, res as Response);
@@ -108,13 +116,15 @@ describe('ExerciseController - updateExerciseStatus', () => {
     });
 
     it('deve retornar "Internal server error while processing the request" em caso de erro no servidor', async () => {
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" });
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date });
         mockExerciseService.validateStatus.mockResolvedValue(true)
-        
+
         mockExerciseService.findProgress.mockRejectedValue(new Error("Internal server error"));
-    
+
         await controller.updateExerciseStatus(req as Request, res as Response)
-    
+
         expect(res.status).toHaveBeenCalledWith(500)
         expect(res.json).toHaveBeenCalledWith({ message: "Internal server error while processing the request" })
     })
@@ -155,7 +165,9 @@ describe('ExerciseController - getTopicExercisesStatus', () => {
     })
 
     it("deve retornar 'Progresso não encontrado' se o status do exercício não for encontrado", async () => {
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email:"teste@gmail.com" })
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.getStatus.mockResolvedValue([])
 
         await controller.getTopicExercisesStatus(req as Request, res as Response)
@@ -180,10 +192,12 @@ describe('ExerciseController - getTopicExercisesStatus', () => {
             itemStatus: ItemStatus;
             elementType: ElementType;
         }[] = [
-            { itemId: "1", itemStatus: ItemStatus.Completed, elementType: ElementType.Exercise },
-        ]
+                { itemId: "1", itemStatus: ItemStatus.Completed, elementType: ElementType.Exercise },
+            ]
 
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.getStatus.mockResolvedValue(statusList)
 
         await controller.getTopicExercisesStatus(req as Request, res as Response)
@@ -191,24 +205,24 @@ describe('ExerciseController - getTopicExercisesStatus', () => {
         expect(res.status).toHaveBeenCalledWith(200)
         expect(res.json).toHaveBeenCalledWith(statusList)
     })
-   
+
 })
 
 describe("ExerciseController - getExerciseStatus", () => {
-   
+
     beforeEach(() => {
         mockExerciseService = new ExerciseService() as jest.Mocked<ExerciseService>
-    
+
         controller = new ExerciseController()
         controller["exerciseService"] = mockExerciseService
-    
-        req = { params: { topicId: "1", itemId: "2" }, user: { email: "teste@gmail.com" }, } 
+
+        req = { params: { topicId: "1", itemId: "2" }, user: { email: "teste@gmail.com" }, }
         res = {
             status: jest.fn().mockReturnThis(),
             json: jest.fn(),
-        } 
+        }
     })
-    
+
     it("deve retornar 'Usuário não autenticado' se o email não existir", async () => {
         req.user = undefined
 
@@ -216,7 +230,7 @@ describe("ExerciseController - getExerciseStatus", () => {
 
         expect(res.status).toHaveBeenCalledWith(401)
         expect(res.json).toHaveBeenCalledWith({ message: "User not authenticated" })
-    })    
+    })
 
     it("deve retornar 'Usuário não encontrado' se o usuário não existir", async () => {
         mockExerciseService.findUserByEmail.mockResolvedValue(null)
@@ -228,62 +242,69 @@ describe("ExerciseController - getExerciseStatus", () => {
     })
 
     it("deve retornar 'itemId não encontrado' se o itemId não existir", async () => {
-        
+
         req.params = { ...req.params, itemId: "" }
-        
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.exerciseStatus.mockResolvedValue([])
-        
+
         await controller.getExerciseStatus(req as Request, res as Response)
-        
+
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.json).toHaveBeenCalledWith({ message: "itemId not found" })
     })
 
     it("deve retornar 'topicId não encontrado' se o topicId não existir", async () => {
-        
+
         req.params = { ...req.params, topicId: "" }
-        
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.exerciseStatus.mockResolvedValue([])
-        
+
         await controller.getExerciseStatus(req as Request, res as Response)
-        
+
         expect(res.status).toHaveBeenCalledWith(400)
         expect(res.json).toHaveBeenCalledWith({ message: "topicId not found" })
     })
 
     it("deve retornar 'topicId inválido' se o topicId for inválido", async () => {
-        
+
         req.params = { ...req.params, topicId: "rw1726148766181e6da" }
 
-        
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.findTopicById.mockResolvedValue(null)
-        
+
         await controller.getExerciseStatus(req as Request, res as Response)
-        
+
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.json).toHaveBeenCalledWith({ message: "topicId invalid" })
     })
 
     it("deve retornar 'status não encontrado' se o status não for encontrado", async () => {
-        
-        const topicValidation: {id: number; itemId: string; elementType: ElementType; userId: number; itemStatus: ItemStatus; topicId: string} = {
+
+        const topicValidation: { id: number; itemId: string; elementType: ElementType; userId: number; itemStatus: ItemStatus; topicId: string } = {
             id: 1,
             itemId: "rw1726148766181e6dab5",
             elementType: ElementType.Exercise,
             userId: 1,
             itemStatus: ItemStatus.Completed,
             topicId: "rw17212367802520ba251"
-            }
-        
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+        }
+
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.findTopicById.mockResolvedValue(topicValidation)
         mockExerciseService.exerciseStatus.mockResolvedValue([])
-        
+
         await controller.getExerciseStatus(req as Request, res as Response)
-        
+
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.json).toHaveBeenCalledWith({ message: "Status not found" })
     })
@@ -298,28 +319,30 @@ describe("ExerciseController - getExerciseStatus", () => {
     })
 
     it("deve retornar um objeto com itemStatus e itemId quando disponível", async () => {
-        
-        const topicValidation: {id: number; itemId: string; elementType: ElementType; userId: number; itemStatus: ItemStatus; topicId: string} = {
+
+        const topicValidation: { id: number; itemId: string; elementType: ElementType; userId: number; itemStatus: ItemStatus; topicId: string } = {
             id: 1,
             itemId: "rw1726148766181e6dab5",
             elementType: ElementType.Exercise,
             userId: 1,
             itemStatus: ItemStatus.Completed,
             topicId: "rw17212367802520ba251"
-            }
+        }
 
-        const exerciseSuccess: { itemStatus: ItemStatus; itemId: string } [] = [{
-            
+        const exerciseSuccess: { itemStatus: ItemStatus; itemId: string }[] = [{
+
             itemStatus: ItemStatus.InProgress,
             itemId: "rw1726148766181e6dab5"
         }]
 
-        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com" })
+        const date: Date = new Date(2025, 1, 24)
+
+        mockExerciseService.findUserByEmail.mockResolvedValue({ id: 1, email: "teste@gmail.com", provider: "google", loginDate: date })
         mockExerciseService.findTopicById.mockResolvedValue(topicValidation)
         mockExerciseService.exerciseStatus.mockResolvedValue(exerciseSuccess)
-        
+
         await controller.getExerciseStatus(req as Request, res as Response)
-        
+
         expect(res.status).toHaveBeenCalledWith(200)
         expect(res.json).toHaveBeenCalledWith(exerciseSuccess)
     })

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -48,7 +48,7 @@ export class ExerciseController {
             if (error.message.includes("not found") || error.message.includes("Invalid")) {
                 return res.status(400).json({ message: error.message })
             }
-            console.error(`Error in updateExerciseStatus: ${error.message}`)
+          
             return res.status(500).json({ message: "Internal server error while processing the request" })
         }
     }

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -1,5 +1,5 @@
 import { Response, Request } from "express"
-import { ExerciseService } from "../services/ExerciseService"
+import { ExerciseService } from "../../services/ExerciseService"
 
 export class ExerciseController {
     private exerciseService: ExerciseService

--- a/src/controllers/login/LoginController.test.ts
+++ b/src/controllers/login/LoginController.test.ts
@@ -30,4 +30,24 @@ describe('LoginController - registerUser', () => {
         expect(res.status).toHaveBeenCalledWith(498)
         expect(res.json).toHaveBeenCalledWith({ message: "Expired or invalid token" })
     })
+    it('Verifica se ocorreu erro ao extrair o token, deve retornar: "Error extracting token"', async () => {
+       
+        mockTokenService.extractToken.mockResolvedValue(null)
+
+        await controller.registerUser(req as Request, res as Response)
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(res.json).toHaveBeenCalledWith({message: "Error extracting token"})
+    })
+
+    it('Verifica se o usuário existe no banco de dados, deve retornar: "User already exists"', async () => {
+
+        const date: Date = new Date(2025, 1, 24)
+        mockTokenService.extractToken.mockResolvedValue({name:"Milena", email:"usuariaaceleradora@gmail.com", sub:"1568888", id:"1", provider:"google", accessToken:"kmmxddvbh", iat:4567, exp:5689, jti:"njjdkmk"})
+        mockTokenService.findUserByEmail.mockResolvedValue({id:1, email:"usuariaaceleradora@gmail.com", provider:"google", loginDate:date})
+
+        await controller.registerUser( req as Request, res as Response)
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({message: "User already exists"})
+    })
+    
 })

--- a/src/controllers/login/LoginController.test.ts
+++ b/src/controllers/login/LoginController.test.ts
@@ -1,0 +1,33 @@
+
+import { Request, Response } from "express"
+import { TokenService } from "../../services/TokenService"
+import { LoginController } from "./LoginController"
+
+jest.mock("../../services/TokenService")
+let controller: LoginController
+let req: Partial<Request>
+let res: Partial<Response>
+let mockTokenService: jest.Mocked<TokenService>
+
+describe('LoginController - registerUser', () => {
+
+    beforeEach(() => {
+        mockTokenService = new TokenService() as jest.Mocked<TokenService>
+
+        controller = new LoginController()
+        controller['tokenService'] = mockTokenService
+
+        req = {user: { email: "test@gmail.com" }, headers: {authorization: "Bearer algo2"} }
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        }
+    })
+    it('Verifica se o token é invalido ou expirado, deve retornar: "Expired or invalid token"', async () => {
+        req =  {headers: {authorization: "kaaa"}}
+
+        await controller.registerUser(req as Request, res as Response)
+        expect(res.status).toHaveBeenCalledWith(498)
+        expect(res.json).toHaveBeenCalledWith({ message: "Expired or invalid token" })
+    })
+})

--- a/src/controllers/login/LoginController.test.ts
+++ b/src/controllers/login/LoginController.test.ts
@@ -1,4 +1,3 @@
-
 import { Request, Response } from "express"
 import { TokenService } from "../../services/TokenService"
 import { LoginController } from "./LoginController"
@@ -9,45 +8,125 @@ let req: Partial<Request>
 let res: Partial<Response>
 let mockTokenService: jest.Mocked<TokenService>
 
-describe('LoginController - registerUser', () => {
+describe("LoginController - registerUser", () => {
+  beforeEach(() => {
+    mockTokenService = new TokenService() as jest.Mocked<TokenService>
 
-    beforeEach(() => {
-        mockTokenService = new TokenService() as jest.Mocked<TokenService>
+    controller = new LoginController()
+    controller["tokenService"] = mockTokenService
 
-        controller = new LoginController()
-        controller['tokenService'] = mockTokenService
+    req = {
+      user: { email: "test@gmail.com" },
+      headers: { authorization: "Bearer eysncskwnsopmcsabuwsa" },
+    }
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+  })
 
-        req = {user: { email: "test@gmail.com" }, headers: {authorization: "Bearer algo2"} }
-        res = {
-            status: jest.fn().mockReturnThis(),
-            json: jest.fn()
-        }
+  it('Verifica se o token é expirado ou invalido, deve retornar: "Expired or invalid token"', async () => {
+    req = { headers: { authorization: "eynkdsflmdnas" } }
+
+    await controller.registerUser(req as Request, res as Response)
+    expect(res.status).toHaveBeenCalledWith(498)
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Expired or invalid token",
     })
-    it('Verifica se o token é invalido ou expirado, deve retornar: "Expired or invalid token"', async () => {
-        req =  {headers: {authorization: "kaaa"}}
+  })
 
-        await controller.registerUser(req as Request, res as Response)
-        expect(res.status).toHaveBeenCalledWith(498)
-        expect(res.json).toHaveBeenCalledWith({ message: "Expired or invalid token" })
+  it('Verifica se ocorreu erro ao extrair o token, deve retornar: "Error extracting token"', async () => {
+    mockTokenService.extractToken.mockResolvedValue(null)
+
+    await controller.registerUser(req as Request, res as Response)
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Error extracting token",
     })
-    it('Verifica se ocorreu erro ao extrair o token, deve retornar: "Error extracting token"', async () => {
-       
-        mockTokenService.extractToken.mockResolvedValue(null)
+  })
 
-        await controller.registerUser(req as Request, res as Response)
-        expect(res.status).toHaveBeenCalledWith(500)
-        expect(res.json).toHaveBeenCalledWith({message: "Error extracting token"})
+  it('Verifica se o usuário existe no banco de dados, deve retornar: "User already exists"', async () => {
+    const date: Date = new Date(2025, 1, 25)
+
+    mockTokenService.extractToken.mockResolvedValue({
+      name: "Milena",
+      email: "usuariaaceleradora@gmail.com",
+      sub: "1568888",
+      id: "1",
+      provider: "google",
+      accessToken: "eysdnsdnsakns",
+      iat: 4567,
+      exp: 5689,
+      jti: "njjdkmk",
     })
 
-    it('Verifica se o usuário existe no banco de dados, deve retornar: "User already exists"', async () => {
-
-        const date: Date = new Date(2025, 1, 24)
-        mockTokenService.extractToken.mockResolvedValue({name:"Milena", email:"usuariaaceleradora@gmail.com", sub:"1568888", id:"1", provider:"google", accessToken:"kmmxddvbh", iat:4567, exp:5689, jti:"njjdkmk"})
-        mockTokenService.findUserByEmail.mockResolvedValue({id:1, email:"usuariaaceleradora@gmail.com", provider:"google", loginDate:date})
-
-        await controller.registerUser( req as Request, res as Response)
-        expect(res.status).toHaveBeenCalledWith(200)
-        expect(res.json).toHaveBeenCalledWith({message: "User already exists"})
+    mockTokenService.findUserByEmail.mockResolvedValue({
+      id: 1,
+      email: "usuariaaceleradora@gmail.com",
+      provider: "google",
+      loginDate: date,
     })
-    
+
+    await controller.registerUser(req as Request, res as Response)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ message: "User already exists" })
+  })
+
+  it('Verifica se ocorreu um erro ao registrar o usuário, deve retornar: "Error registering user"', async () => {
+
+    mockTokenService.extractToken.mockResolvedValue({
+      name: "Milena",
+      email: "usuariaaceleradora@gmail.com",
+      sub: "1568888",
+      id: "1",
+      provider: "google",
+      accessToken: "eysdnsdnsakns",
+      iat: 4567,
+      exp: 5689,
+      jti: "njjdkmk",
+    })
+
+    mockTokenService.findUserByEmail.mockResolvedValue(null)
+
+    mockTokenService.registerUser.mockResolvedValue(null)
+
+    await controller.registerUser(req as Request, res as Response)
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Error registering user",
+    })
+  })
+
+  it('Verifica se o usuário foi criado com sucesso , deve retornar: "User created successfully!"', async () => {
+    const date: Date = new Date(2025, 1, 25)
+
+    mockTokenService.extractToken.mockResolvedValue({
+        name: "Milena",
+        email: "usuariaaceleradora@gmail.com",
+        sub: "1568888",
+        id: "1",
+        provider: "google",
+        accessToken: "eysdnsdnsakns",
+        iat: 4567,
+        exp: 5689,
+        jti: "njjdkmk",
+      })
+
+    mockTokenService.findUserByEmail.mockResolvedValue(null)
+
+    mockTokenService.registerUser.mockResolvedValue({
+      id: 2,
+      email: "test@gmail.com",
+      provider: "github",
+      loginDate: date,
+    })
+
+    await controller.registerUser(req as Request, res as Response)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      message: "User created successfully!",
+    })
+  })
 })

--- a/src/controllers/login/LoginController.ts
+++ b/src/controllers/login/LoginController.ts
@@ -1,0 +1,6 @@
+import { TokenService } from "../../services/TokenService";
+
+export class LoginController {
+    private tokenService: TokenService
+
+}

--- a/src/controllers/login/LoginController.ts
+++ b/src/controllers/login/LoginController.ts
@@ -1,6 +1,46 @@
-import { TokenService } from "../../services/TokenService";
+import { TokenService } from "../../services/TokenService"
+import { Response, Request } from "express"
 
 export class LoginController {
-    private tokenService: TokenService
+  private tokenService: TokenService
 
+  constructor() {
+    this.tokenService = new TokenService()
+  }
+
+  async registerUser(req: Request, res: Response) {
+    const token = req.headers.authorization?.split(" ")[1]
+
+    if (!token) {
+      return res.status(498).json({ message: "Expired or invalid token" })
+    }
+
+    try {
+      const extractToken = await this.tokenService.extractToken(token)
+
+      if (!extractToken) {
+        return res.status(500).json({ message: "Error extracting token" })
+      }
+
+      const findUser = await this.tokenService.findUserByEmail(
+        extractToken.email
+      )
+
+      if (findUser) {
+        return res.status(200).json({ message: "User already exists" })
+      }
+
+      const createdUser = await this.tokenService.registerUser(extractToken)
+
+      if (!createdUser) {
+        return res.status(500).json({ message: "Error registering user" })
+      }
+
+      return res.status(200).json({ message: "User created successfully!" })
+    } catch (error: any) {
+      return res
+        .status(500)
+        .json({ message: "Error processing the created user" })
+    }
+  }
 }

--- a/src/middleware/validateTokenMiddleware.ts
+++ b/src/middleware/validateTokenMiddleware.ts
@@ -12,7 +12,7 @@ export async function validateTokenMiddleware(req: Request, res: Response, next:
     const email = extractToken?.email
     try {
         if (!email) {
-            return res.status(401).json({ message: "Token invalid" });
+            return res.status(498).json({ message: "Token invalid" });
         }
         req.user = { email };
         next();

--- a/src/middleware/validateTokenMiddleware.ts
+++ b/src/middleware/validateTokenMiddleware.ts
@@ -8,9 +8,9 @@ export async function validateTokenMiddleware(req: Request, res: Response, next:
     if (!token) {
         return res.status(401).json({ message: "Token was not provided" });
     }
-    const email = await tokenService.extractEmailToken(token);
+    const extractToken = await tokenService.extractToken(token);
+    const email = extractToken?.email
     try {
-
         if (!email) {
             return res.status(401).json({ message: "Token invalid" });
         }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { ExerciseController } from '../controllers/exercise/ExerciseController'
 import { validateTokenMiddleware } from '../middleware/validateTokenMiddleware'
+import { LoginController } from '../controllers/login/LoginController'
 
 const router = express.Router()
 
@@ -8,7 +9,7 @@ router.get('/', (req, res) => {
     res.send('Welcome to the homepage')
 })
 
-router.get('/login', validateTokenMiddleware, (req, res) => new ExerciseController().updateExerciseStatus(req, res))
+router.get('/login', validateTokenMiddleware, (req, res) => new LoginController().registerUser(req, res))
 
 router.put('/topic/:topicId/item/:itemId/status', validateTokenMiddleware, (req, res) => new ExerciseController().updateExerciseStatus(req, res))
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { ExerciseController } from '../controllers/ExerciseController'
+import { ExerciseController } from '../controllers/exercise/ExerciseController'
 import { validateTokenMiddleware } from '../middleware/validateTokenMiddleware'
 
 const router = express.Router()
@@ -7,6 +7,8 @@ const router = express.Router()
 router.get('/', (req, res) => {
     res.send('Welcome to the homepage')
 })
+
+router.get('/login', validateTokenMiddleware, (req, res) => new ExerciseController().updateExerciseStatus(req, res))
 
 router.put('/topic/:topicId/item/:itemId/status', validateTokenMiddleware, (req, res) => new ExerciseController().updateExerciseStatus(req, res))
 

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -1,13 +1,30 @@
 import * as dotenv from 'dotenv';
 import * as jose from 'jose';
 import * as crypto from 'crypto';
+import { PrismaClient } from "@prisma/client"
 
 dotenv.config();
+
+const prisma = new PrismaClient()
+
+interface UserToken {
+    name: string,
+    email: string,
+    sub: string,
+    id: string,
+    provider: string,
+    accessToken: string,
+    iat: number,
+    exp: number,
+    jti: string
+  }
 
 export class TokenService {
     private secretKey = process.env.NEXTAUTH_SECRET || "";
 
-    async extractEmailToken(token: string): Promise<string | null> {
+    // CRIAR TIPO PARA TOKEN
+
+    async extractToken(token: string): Promise<UserToken | null> {
         if (!this.secretKey) {
             throw new Error('Secret key not found');
         }
@@ -33,15 +50,27 @@ export class TokenService {
             const { plaintext } = await jose.compactDecrypt(token, keyUint8Array);
             const decodedToken = JSON.parse(new TextDecoder().decode(plaintext));
 
-            if (!decodedToken || typeof decodedToken.email !== "string") {
-                console.error("Token inválido ou sem email:", decodedToken);
+            if (!decodedToken) {
+                console.error("Token inválido");
                 return null;
             }
-            return decodedToken.email;
+            return decodedToken;
 
         } catch (error: any) {
             console.error("Erro na descriptografia do token:", error);
             return null;
         }
     }
+
+    // async registerUser(token: string) {
+    //     try {
+    //         const email = await this.extractEmailToken(token)
+
+    //         if(email){
+    //             const user = prisma.user.findFirst({ where: {email, provider}})
+    //         }
+    //     } catch (error) {
+            
+    //     }
+    // }
 }

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -1,102 +1,95 @@
-import * as dotenv from 'dotenv';
-import * as jose from 'jose';
-import * as crypto from 'crypto';
+import * as dotenv from "dotenv"
+import * as jose from "jose"
+import * as crypto from "crypto"
 import { PrismaClient } from "@prisma/client"
 
-dotenv.config();
+dotenv.config()
 
 const prisma = new PrismaClient()
 
 interface UserToken {
-    name: string,
-    email: string,
-    sub: string,
-    id: string,
-    provider: string,
-    accessToken: string,
-    iat: number,
-    exp: number,
-    jti: string
+  name: string
+  email: string
+  sub: string
+  id: string
+  provider: string
+  accessToken: string
+  iat: number
+  exp: number
+  jti: string
 }
 
 export class TokenService {
-    private secretKey = process.env.NEXTAUTH_SECRET || "";
+  private secretKey = process.env.NEXTAUTH_SECRET || ""
 
-    // CRIAR TIPO PARA TOKEN
-
-    async extractToken(token: string): Promise<UserToken | null> {
-        if (!this.secretKey) {
-            throw new Error('Secret key not found');
-        }
-        try {
-            const salt = Buffer.alloc(16);
-
-            const key = await new Promise<Buffer>((resolve, reject) => {
-                crypto.hkdf(
-                    'sha256',
-                    Buffer.from(this.secretKey, 'utf-8'),
-                    salt,
-                    Buffer.from('NextAuth.js Generated Encryption Key', 'utf-8'),
-                    32,
-                    (err, derivedKey) => {
-                        if (err) reject(err);
-                        else resolve(Buffer.from(derivedKey));
-                    }
-                );
-            });
-
-            const keyUint8Array = new Uint8Array(key);
-
-            const { plaintext } = await jose.compactDecrypt(token, keyUint8Array);
-            const decodedToken = JSON.parse(new TextDecoder().decode(plaintext));
-
-            if (!decodedToken) {
-                console.error("Token inválido");
-                return null;
-            }
-
-            return decodedToken;
-
-        } catch (error: any) {
-            console.error("Erro na descriptografia do token:", error);
-            return null;
-        }
+  async extractToken(token: string): Promise<UserToken | null> {
+    if (!this.secretKey) {
+      throw new Error("Secret key not found")
     }
+    try {
+      const salt = Buffer.alloc(16)
 
-    async registerUser(token: string) {
-        try {
-            const extractToken = await this.extractToken(token)
+      const key = await new Promise<Buffer>((resolve, reject) => {
+        crypto.hkdf(
+          "sha256",
+          Buffer.from(this.secretKey, "utf-8"),
+          salt,
+          Buffer.from("NextAuth.js Generated Encryption Key", "utf-8"),
+          32,
+          (err, derivedKey) => {
+            if (err) reject(err)
+            else resolve(Buffer.from(derivedKey))
+          }
+        )
+      })
 
-            if (extractToken) {
-                const findUser = await prisma.user.findUnique({ where: { email: extractToken.email } })
+      const keyUint8Array = new Uint8Array(key)
 
-                if (findUser) {
-                    throw new Error("User already exists")
-                }
+      const { plaintext } = await jose.compactDecrypt(token, keyUint8Array)
+      const decodedToken = JSON.parse(new TextDecoder().decode(plaintext))
 
+      if (!decodedToken) {
+        console.error("Invalid token")
+        return null
+      }
 
-                const convertIatToDateTime = (iat: number): Date => {
-                    return new Date(iat * 1000)
-                }
-
-                const iat = extractToken.iat;
-                const dateTime = convertIatToDateTime(iat);
-
-                const createUser = await prisma.user.create({
-                    data: {
-                        email: extractToken.email,
-                        provider: extractToken.provider,
-                        loginDate: dateTime,
-                    },
-                })
-
-                if(!createUser) throw new Error("Error creating user")
-
-                return createUser
-            }
-        } catch (error) {
-            console.error(error)
-            return null
-        }
+      return decodedToken
+    } catch (error: any) {
+      console.error("Error decrypting token:", error)
+      return null
     }
+  }
+
+  async registerUser(extractToken: UserToken) {
+    try {
+      const convertIatToDateTime = (iat: number): Date => {
+        return new Date(iat * 1000)
+      }
+
+      const iat = extractToken.iat
+      const dateTime = convertIatToDateTime(iat)
+
+      const createUser = await prisma.user.create({
+        data: {
+          email: extractToken.email,
+          provider: extractToken.provider,
+          loginDate: dateTime,
+        },
+      })
+
+      return createUser
+    } catch (error) {
+      console.error(error)
+      return null
+    }
+  }
+
+  async findUserByEmail(email: string) {
+    try {
+      const user = await prisma.user.findUnique({ where: { email } })
+      return user
+    } catch (error) {
+      throw new Error("Error fetching user from database")
+    }
+  }
 }

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -71,7 +71,7 @@ export class TokenService {
                 const findUser = await prisma.user.findUnique({ where: { email: extractToken.email } })
 
                 if (findUser) {
-                    throw new Error("")
+                    throw new Error("User already exists")
                 }
 
 
@@ -86,16 +86,16 @@ export class TokenService {
                     data: {
                         email: extractToken.email,
                         provider: extractToken.provider,
-                        loginDate: dateTime.toLocaleString("pt-BR"),
+                        loginDate: dateTime,
                     },
                 })
 
-                if(!createUser) return null
+                if(!createUser) throw new Error("Error creating user")
 
                 return createUser
             }
         } catch (error) {
-            console.error("Erro ao registrar usuario: ", error)
+            console.error(error)
             return null
         }
     }


### PR DESCRIPTION
# <13> - Feat Endpoint para salvar usuário
  
### 🆙 CHANGELOG

- Adição de provider e loginDate no prisma;
- Adição no TokenService.ts métodos para extrair token, adicionar usuário e verificar se o usuário já existe;
- Criamos uma controller para separar a lógica da Service;
- Criação de rota para o login;
- Criamos testes unitários para o LoginController;

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Garantir que main esteja atualizada com `git pull`
- [ ] Ir para branch 13
- [ ] Pegar o acessToken no front end(rodar front end, logar com alguma conta, na ferramenta do desenvolvedor na Application, ir em Cookies e pegar o valor que está next-auth-session)
- [ ] Abrir Postman e configurar uma rota GET que vai levar a URL: **www.localhost:5002/login**
- [ ] Adicionar no headers um campo de **Authorization** que vai receber **Bearer (token que você copiu do front)**
- [ ] Testar cenários com a rota. Ex: criar um usuário que já existe, tentar criar um usuário sem token... seja criativo :)
- [ ] Verificar qualidade do código
- [ ] Rodar testes com `npm test`
