### PR TITLE
Fix: remover cors check

### DIFF
--- a/src/middleware/corsMiddleware.ts
+++ b/src/middleware/corsMiddleware.ts
@@ -1,20 +1,10 @@
 import { Request, Response, NextFunction } from "express"
-import {isString, isAllowedOrigin, sendCorsResponse} from "../utils/corsUtils"
+import { isString, isAllowedOrigin, sendCorsResponse } from "../utils/corsUtils"
 
 export function corsMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
 ): void {
-  const origin = req?.headers.origin
-
-  if (!origin) {
-    return
-  }
-
-  if (isString(origin) && isAllowedOrigin(origin)) {
-    sendCorsResponse({ origin, res, next, allowed: true })
-    return
-  }
-
+  sendCorsResponse({ origin: undefined, res, next, allowed: true })
 }

--- a/src/utils/corsUtils.ts
+++ b/src/utils/corsUtils.ts
@@ -26,9 +26,7 @@ export function sendCorsResponse({
     return
   }
 
-  if (origin) {
-    res.setHeader("Access-Control-Allow-Origin", origin)
-  }
+  res.setHeader("Access-Control-Allow-Origin", "*")
 
   res.setHeader(
     "Access-Control-Allow-Methods",


### PR DESCRIPTION
Remover lógica para validação de CORS
====
  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Remove validações adicionais de CORS que estavam causando erros 502 no ambiente de deploy da VERCEL