### PR TITLE
158/fix salvamento status backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# editor
+.vscode

--- a/prisma/migrations/20250520155458_/migration.sql
+++ b/prisma/migrations/20250520155458_/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[itemId,userId]` on the table `Progress` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Progress_itemId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Progress_itemId_userId_key" ON "Progress"("itemId", "userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,22 +8,24 @@ datasource db {
 }
 
 model User {
-  id       Int        @id @default(autoincrement())
-  email    String     @unique
-  provider String     
+  id        Int        @id @default(autoincrement())
+  email     String     @unique
+  provider  String
   loginDate DateTime
-  Progress Progress[]
+  Progress  Progress[]
 }
 
 model Progress {
   id          Int         @id @default(autoincrement())
-  itemId      String      @unique
+  itemId      String
   itemStatus  ItemStatus
   elementType ElementType
   topicId     String      @default("default-topic-id")
-  modifiedAt  DateTime
+  modifiedAt  DateTime    @updatedAt
   userId      Int
   user        User        @relation(fields: [userId], references: [id])
+
+  @@unique([itemId, userId])
 }
 
 enum ItemStatus {

--- a/src/controllers/exercise/ExerciseController.test.ts
+++ b/src/controllers/exercise/ExerciseController.test.ts
@@ -78,7 +78,7 @@ describe("ExerciseController - updateExerciseStatus", () => {
     });
   });
 
-  it('deve retornar "Progress record not found for user 1 and item 1, 1" se o progresso não for encontrado', async () => {
+  it("deve retornar o progresso atualizado ao mudar o status ou criar um novo registro", async () => {
     const date: Date = new Date(2025, 1, 24);
 
     mockExerciseService.findUserByEmail.mockResolvedValue({
@@ -90,81 +90,17 @@ describe("ExerciseController - updateExerciseStatus", () => {
 
     mockExerciseService.validateStatus.mockReturnValue(true);
 
-    mockExerciseService.findProgress.mockRejectedValue(
-      new Error("Progress record not found for user 1 and item 1, 1.")
-    );
-
-    await controller.updateExerciseStatus(req as Request, res as Response);
-
-    expect(res.status).toHaveBeenCalledWith(STATUS_CODE.BAD_REQUEST);
-    expect(res.json).toHaveBeenCalledWith({
-      message: "Progress record not found for user 1 and item 1, 1.",
-    });
-  });
-
-  it('deve retornar "The status is already up to date" se o status já estiver atualizado', async () => {
-    const date: Date = new Date(2025, 1, 24);
-
-    mockExerciseService.findUserByEmail.mockResolvedValue({
-      id: 1,
-      email: "teste@gmail.com",
-      provider: "google",
-      loginDate: date,
-    });
-
-    mockExerciseService.validateStatus.mockReturnValue(true);
-
-    mockExerciseService.findProgress.mockResolvedValue({
-      id: 1,
-      itemId: "rw12346789",
-      itemStatus: "NotStarted",
-      elementType: "Exercise",
-      topicId: "rw987654321",
-      userId: 1,
-      modifiedAt: new Date(),
-    });
-
-    await controller.updateExerciseStatus(req as Request, res as Response);
-
-    expect(res.status).toHaveBeenCalledWith(STATUS_CODE.OK);
-    expect(res.json).toHaveBeenCalledWith({
-      message: "Status value is already being used",
-    });
-  });
-
-  it("deve retornar o progresso atualizado ao mudar o status", async () => {
-    const date: Date = new Date(2025, 1, 24);
-
-    mockExerciseService.findUserByEmail.mockResolvedValue({
-      id: 1,
-      email: "teste@gmail.com",
-      provider: "google",
-      loginDate: date,
-    });
-
-    mockExerciseService.validateStatus.mockReturnValue(true);
-
-    mockExerciseService.findProgress.mockResolvedValue({
-      id: 1,
-      itemId: "rw12346789",
-      itemStatus: "InProgress",
-      elementType: "Exercise",
-      topicId: "rw987654321",
-      userId: 1,
-      modifiedAt: new Date(),
-    });
-
-    const progress = [
-      {
+    const progress = {
         id: 1,
         itemId: "rw12346789",
-        itemStatus: ItemStatus.NotStarted,
+        itemStatus: ItemStatus.InProgress,
         elementType: ElementType.Exercise,
+        topicId: "rw987654321",
         userId: 1,
-      },
-    ];
+        modifiedAt: new Date(),
+      }
 
-    mockExerciseService.updatedProgress.mockResolvedValue(progress);
+    mockExerciseService.saveStatus.mockResolvedValue(progress);
 
     await controller.updateExerciseStatus(req as Request, res as Response);
 
@@ -183,7 +119,7 @@ describe("ExerciseController - updateExerciseStatus", () => {
     });
     mockExerciseService.validateStatus.mockReturnValue(true);
 
-    mockExerciseService.findProgress.mockRejectedValue(
+    mockExerciseService.saveStatus.mockRejectedValue(
       new Error("Internal server error")
     );
 
@@ -375,6 +311,7 @@ describe("ExerciseController - getExerciseStatus", () => {
       provider: "google",
       loginDate: date,
     });
+    // @ts-expect-error 
     mockExerciseService.findTopicById.mockResolvedValue(null);
 
     await controller.getExerciseStatus(req as Request, res as Response);

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -14,7 +14,7 @@ export class ExerciseController {
     const { topicId } = req.params;
     const { elementType, itemStatus } = req.body;
     const email = req.user?.email;
-
+    
     try {
       if (!email) {
         return res
@@ -36,17 +36,6 @@ export class ExerciseController {
         return res
           .status(400)
           .json({ message: "Invalid or missing status value." });
-      }
-
-      const currentProgress = await this.exerciseService.findProgress(
-        user.id,
-        itemId,
-        topicId,
-        elementType
-      );
-
-      if (!currentProgress) {
-        return 
       }
 
       const updatedProgress = await this.exerciseService.saveStatus(

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -12,7 +12,7 @@ export class ExerciseController {
   async updateExerciseStatus(req: Request, res: Response) {
     const { itemId } = req.params;
     const { topicId } = req.params;
-    const { itemStatus } = req.body;
+    const { elementType, itemStatus } = req.body;
     const email = req.user?.email;
 
     try {
@@ -41,24 +41,18 @@ export class ExerciseController {
       const currentProgress = await this.exerciseService.findProgress(
         user.id,
         itemId,
-        topicId
+        topicId,
+        elementType
       );
 
       if (!currentProgress) {
-        return res
-          .status(STATUS_CODE.NOT_FOUND)
-          .json({ message: "Progress not found for the exercise" });
+        return 
       }
 
-      if (currentProgress.itemStatus === itemStatus) {
-        return res
-          .status(STATUS_CODE.OK)
-          .json({ message: "Status value is already being used" });
-      }
-
-      const updatedProgress = await this.exerciseService.updatedProgress(
-        user.id,
+      const updatedProgress = await this.exerciseService.saveStatus(
         itemId,
+        elementType,
+        user.id,
         itemStatus,
         topicId
       );
@@ -71,7 +65,7 @@ export class ExerciseController {
       ) {
         return res
           .status(STATUS_CODE.BAD_REQUEST)
-          .json({ message: error.message });
+          .json({ message: error.message, error });
       }
 
       return res

--- a/src/services/ExerciseService.ts
+++ b/src/services/ExerciseService.ts
@@ -149,20 +149,24 @@ export class ExerciseService {
     }
     
     async saveStatus(itemId: string, elementType: ElementType, userId: number, itemStatus: ItemStatus, topicId: string) {
-        const dateTime = await this.formatDateTime() 
         try {
             const createdProgress = await prisma.progress.upsert({
-                where: { itemId, userId },
+                where: { 
+                    itemId_userId: {
+                        itemId,
+                        userId
+                    },
+                },
+                update: { itemStatus },
                 create: {
                     itemId,
                     elementType,
                     userId,
                     itemStatus,
-                    topicId,
-                    modifiedAt: dateTime
-                },
-                update: { itemStatus, modifiedAt: dateTime }
-            })  
+                    topicId
+                }
+            })
+
             return createdProgress
         } catch(error){
             throw new Error("Error saving progress status")


### PR DESCRIPTION
#158 - fix: ajuste para que o salvamento de status acione os endpoints
====
  
### 🆙 CHANGELOG

- **.gitignore**: adicionado a pasta .vscode ao gitignore.
- **src/controllers/exercise/ExerciseController.ts** - Removido as validações de erros caso o status do exercício específico do usuário específico não for encontrado no banco de dados e caso o status enviado seja o mesmo do atual; Adicionado elementType como parâmetro da função saveStatus.
- **src/services/ExerciseService.ts** - Quando não encontra o progresso do usuário específico para o exercício específico, cria um novo registro na base de dados.
- **src/controllers/exercise/ExerciseController.test.ts** - Removido o caso de teste que retornava um erro caso um progresso que não existe no banco de dados tentasse ser atualizado, pois atualmente o fluxo cria o regisitro caso não tenha.
- **prisma/schema.prisma** - Alterado model Progress para que tenha chave composta pelo id do item e do usuário ao invés de termos o id do item como chave primária.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste
- [ ] Verificar modificação 1
- [ ] Verificar modificação 2
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
