### PR TITLE
36/feat  - Adiciona middleware para retorno 404 personalizado 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,14 @@ const port = 5002;
 app.use(express.json());
 app.use(router);
 
+app.use((req, res) => {
+  res.status(404).json({
+    status: 404,
+    error: "Not Found",
+    message: "A rota que você tentou acessar não existe."
+  });
+});
+
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { LoginController } from "../controllers/login/LoginController";
 import { ProgressController } from "../controllers/progress/ProgressController";
 import { StackbyController } from "../controllers/stackby/StackbyController";
 
+
 const router = express.Router();
 
 router.get("/", (req, res) => {
@@ -18,20 +19,33 @@ router.get("/stackBy/:endpoint", (req, res) =>
   new StackbyController().getStackbyData(req, res)
 );
 
-router.use(validateTokenMiddleware);
-
-router.get("/status/:id/:idType", (req, res) =>
-  new ProgressController().getTopicExercisesStatusProgress(req, res)
-);
-router.put("/status/:topicId/item/:itemId", (req, res) =>
-  new ProgressController().saveStatusProgress(req, res)
-);
-router.get("/status/:topicId/item/:itemId", (req, res) =>
-  new ProgressController().getExerciseStatusProgress(req, res)
+router.get(
+  "/status/:id/:idType",
+  validateTokenMiddleware,
+  (req, res) =>
+    new ProgressController().getTopicExercisesStatusProgress(req, res)
 );
 
-router.get("/progress/:id/:idType", (req, res) =>
-  new ProgressController().getProgressPercentageById(req, res)
+router.put(
+  "/status/:topicId/item/:itemId",
+  validateTokenMiddleware,
+  (req, res) =>
+    new ProgressController().saveStatusProgress(req, res)
+);
+
+router.get(
+  "/status/:topicId/item/:itemId",
+  validateTokenMiddleware,
+  (req, res) =>
+    new ProgressController().getExerciseStatusProgress(req, res)
+);
+
+router.get(
+  "/progress/:id/:idType",
+  validateTokenMiddleware,
+  (req, res) =>
+    new ProgressController().getProgressPercentageById(req, res)
 );
 
 export default router;
+


### PR DESCRIPTION
# <36> - Adiciona middleware para retorno 404 personalizado 

🆙 CHANGELOG

- Implementei middleware global para tratar rotas não encontradas (erro 404) com resposta JSON padronizada.
- Ajustei o middleware de autenticação para ser aplicado apenas nas rotas que realmente precisam de token, evitando erros de autenticação em rotas inexistentes.
- Garantir o retorno de mensagens claras e amigáveis ao acessar rotas inválidas.

## ⚠️ Me certifico que:

- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Rodar o backend localmente com o comando: npm run dev
- [x] No navegador, acessar uma rota que não existe, por exemplo: http://localhost:5002/rota-que-nao-existe
- [x] Confirmar que a resposta é um JSON com status 404 e corpo igual a: 

{
  "status": 404,
  "error": "Not Found",
  "message": "A rota que você tentou acessar não existe."
}

- [x] Testar rotas públicas existentes para confirmar que respondem normalmente.
- [x] Testar rotas protegidas (que exigem token) para confirmar que a autenticação funciona normalmente.
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
