### PR TITLE
feat: criamos uma API para filtrar entre os temas de nivelamento e autoestudo 

### DIFF
--- a/src/controllers/stackby/StackbyController.ts
+++ b/src/controllers/stackby/StackbyController.ts
@@ -42,4 +42,32 @@ export class StackbyController {
         .json({ message: "Error processing the request" });
     }
   }
+  async getFilteredThemes(req: Request, res: Response) {
+    try {
+      const typeParam = req.query.type;
+      const type = typeof typeParam === "string" ? typeParam.toLowerCase() : undefined;
+      const permittedTypes = ["nivelamento", "autoestudo"];
+
+      if (type && !permittedTypes.includes(type)) {
+        return res.status(STATUS_CODE.BAD_REQUEST).json({ message: "Invalid type parameter. Must be 'nivelamento' or 'autoestudo'." });
+      }
+      
+      const response = await this.stackyByService.fetchStackbyData("Themes");
+      const allThemes = response?.data || [];
+      const filteredThemes = type ? allThemes.filter((theme: any) => { 
+      const categoria = theme?.field?.category?.toLowerCase?.();
+      return categoria === type;
+    })
+      : allThemes;
+    
+   return res.status(STATUS_CODE.OK).json({ data: filteredThemes });
+  } catch (error) {
+    console.error("Error when searching for themes", error);  
+    if (error instanceof Error) {
+      return res
+        .status(STATUS_CODE.INTERNAL_SERVER_ERROR)
+        .json({ message: "Error processing the request" });
+  }
+  } 
+}
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -19,32 +19,32 @@ router.get("/stackBy/:endpoint", (req, res) =>
   new StackbyController().getStackbyData(req, res)
 );
 
-router.get(
-  "/status/:id/:idType",
+router.get("/status/:id/:idType",
   validateTokenMiddleware,
   (req, res) =>
     new ProgressController().getTopicExercisesStatusProgress(req, res)
 );
 
-router.put(
-  "/status/:topicId/item/:itemId",
+router.put("/status/:topicId/item/:itemId",
   validateTokenMiddleware,
   (req, res) =>
     new ProgressController().saveStatusProgress(req, res)
 );
 
-router.get(
-  "/status/:topicId/item/:itemId",
+router.get("/status/:topicId/item/:itemId",
   validateTokenMiddleware,
   (req, res) =>
     new ProgressController().getExerciseStatusProgress(req, res)
 );
 
-router.get(
-  "/progress/:id/:idType",
-  validateTokenMiddleware,
+router.get("/progress/:id/:idType",
+validateTokenMiddleware,
   (req, res) =>
     new ProgressController().getProgressPercentageById(req, res)
+);
+
+router.get("/themes", (req, res) =>
+new StackbyController().getFilteredThemes(req, res)
 );
 
 export default router;


### PR DESCRIPTION

#<32> - Criamos uma API para filtrar entre os temas de nivelamento e autoestudo
  
### 🆙 CHANGELOG

- Criamos a rota em router -> index.ts um endpoint usando get./themes.
- Implementamos a lógica da filtragem dos temas de Nivelamento e Autoestudo por tipos no StackbyController.ts

## ⚠️ Me certifico que:

- [X] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [X] Solicitei **code review** para 2 pessoas
- [X] Solicitei **QA** para 2 pessoas
- [  ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [X] Entrar no back-end, logo seguida no terminal rodar a aplicação -> npm run dev
- [X] Logo em seguida testar as rotas: 
- http://localhost:5002/themes?type=nivelamento
- http://localhost:5002/themes?type=autoestudo
- http://localhost:5002/themes
- [X] Testar rotas invalidas
- [X] Aplicação não deve conter nenhum erro, warning ou console.log
- [X] Alteração proposta no card foi implementada